### PR TITLE
Make the build "more conventional"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,7 @@ pomExtra := (
 ///////////////////////////
 
 lazy val commonSettings = Seq(
+  organization := "kse",
   scalaVersion := "2.11.7",
   version := "0.4-SNAPSHOT",
   scalacOptions += "-feature",
@@ -40,20 +41,12 @@ lazy val commonSettings = Seq(
 lazy val scalaReflect = Def.setting { "org.scala-lang" % "scala-reflect" % scalaVersion.value }
 lazy val jUnit = "com.novocode" % "junit-interface" % "0.9"
 
-lazy val root = (project in file(".")).
-  dependsOn(macros % "compile-internal, test-internal").
-  settings(commonSettings: _*).
-  settings(
-    name := "Kse",
-    mappings in (Compile, packageBin) ++= mappings.in(macros, Compile, packageBin).value,
-    mappings in (Compile, packageSrc) ++= mappings.in(macros, Compile, packageSrc).value,
-    libraryDependencies += jUnit % Test
-  )
+lazy val kse = project in file(".") aggregate macros dependsOn macros
+commonSettings
+libraryDependencies += jUnit % Test
 
-lazy val macros = (project in file("macros")).
-  settings(commonSettings: _*).
-  settings(
-    libraryDependencies += scalaReflect.value,
-    publish := {},
-    publishLocal := {}
-  )
+lazy val macros = project settings (
+  commonSettings,
+  moduleName := "kse-macros",
+  libraryDependencies += scalaReflect.value
+)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.11


### PR DESCRIPTION
Namely:
- Set `sbt.version` in `project/build.properties` (_very_ important to avoid bitrot)
- Explicitly set the `organization`, using the previous (inferred) value of "kse"
- Dropped `in file("macros")` as it's implied by the name
- Specified "kse-macros" as the artefact name, instead of "macros"
- Setup so macros/kse-macros is aggregated & publishes along with kse

---

Note that this brings a bit of my own flavour of sbt builds, which I'm happy to scale back.

Happy to answer questions and iterate on this if you'd like.
